### PR TITLE
fix: initialize the sampler in the Menustate onInitialize method

### DIFF
--- a/source/states/menu-state.hpp
+++ b/source/states/menu-state.hpp
@@ -59,6 +59,10 @@ class Menustate: public our::State {
         menuMaterial->texture = our::texture_utils::loadImage("assets/textures/menu.png");
         // Initially, the menu material will be black, then it will fade in
         menuMaterial->tint = glm::vec4(0.0f, 0.0f, 0.0f, 0.0f);
+        // Initialize the sampler and set its parameters
+        menuMaterial->sampler = new our::Sampler();
+        menuMaterial->sampler->set(GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        menuMaterial->sampler->set(GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
         // Second, we create a material to highlight the hovered buttons
         highlightMaterial = new our::TintedMaterial();


### PR DESCRIPTION
This pull request includes an enhancement to the `Menustate` class in the `menu-state.hpp` file, specifically focusing on the initialization and configuration of the texture sampler for the menu material.

Changes to texture sampler initialization:

* [`source/states/menu-state.hpp`](diffhunk://#diff-d31f47cb09ce131c06806053171855b000f76f1e3fd7927b578213d35cad36e3R62-R65): Added initialization of the `sampler` for `menuMaterial` and set its parameters for `GL_TEXTURE_MIN_FILTER` and `GL_TEXTURE_MAG_FILTER` to `GL_LINEAR`.