### PR TITLE
Fix staggering

### DIFF
--- a/source/common/components/rigid-body.cpp
+++ b/source/common/components/rigid-body.cpp
@@ -1,4 +1,5 @@
 #include <components/rigid-body.hpp>
+#include <entities/world.hpp>
 #include <deserialize-utils.hpp>
 #include <entities/entity.hpp>
 #include <components/mesh-renderer.hpp>
@@ -54,6 +55,8 @@ namespace our {
 
         // create the rigid body
 	    rigidBody = new btRigidBody(cInfo);
+
+        owner->getWorld()->getPhysicsWorld()->addRigidBody(rigidBody);
     }    
 
     btCollisionShape* RigidBodyComponent::deepCopyCollisionShape(const btCollisionShape* original) {

--- a/source/common/entities/world.cpp
+++ b/source/common/entities/world.cpp
@@ -44,25 +44,6 @@ namespace our
         solver = new btSequentialImpulseConstraintSolver();
         // create the world
         physicsWorld = new btDiscreteDynamicsWorld(dispatcher, broadPhase, solver, collisionConfiguration);
-
-        // physicsWorld->setGravity(btVector3(0, -9.8f, 0)); // Standard gravity
-
-        for (auto entity : entities)
-        {
-            RigidBodyComponent *rigidBody = entity->getComponent<RigidBodyComponent>();
-
-            if (rigidBody)
-            {
-                physicsWorld->addRigidBody(rigidBody->getRigidBody());
-            }
-        }
-
-        debugDrawer = new DebugDrawer();
-        debugDrawer->initialize();
-        debugDrawer->setDebugMode(0);
-        debugDrawer->ToggleDebugFlag(btIDebugDraw::DBG_DrawWireframe);
-
-        physicsWorld->setDebugDrawer(debugDrawer);
     }
 
     void World::shutdownPhysics()

--- a/source/common/systems/physics.hpp
+++ b/source/common/systems/physics.hpp
@@ -24,6 +24,18 @@ namespace our
 
                     rigidBody->getRigidBody()->getMotionState()->getWorldTransform(worldTransform);
 
+                    // Get the current rotation
+                    btQuaternion rotation = worldTransform.getRotation();
+
+                    // Reset X and Z components of the rotation
+                    rotation.setX(0);
+                    rotation.setZ(0);
+                    rotation.normalize();
+
+                    // Apply the modified rotation back to the rigid body
+                    worldTransform.setRotation(rotation);
+                    rigidBody->getRigidBody()->getMotionState()->setWorldTransform(worldTransform);
+
                     entity->localTransform.position.x = worldTransform.getOrigin().getX();
                     entity->localTransform.position.y = worldTransform.getOrigin().getY();
                     entity->localTransform.position.z = worldTransform.getOrigin().getZ();
@@ -31,6 +43,7 @@ namespace our
                     entity->localTransform.rotation.x = worldTransform.getRotation().getX();
                     entity->localTransform.rotation.y = worldTransform.getRotation().getY();
                     entity->localTransform.rotation.z = worldTransform.getRotation().getZ();
+
                 }
             }
 

--- a/source/states/play-state.hpp
+++ b/source/states/play-state.hpp
@@ -31,8 +31,8 @@ class Playstate: public our::State {
         }
         // If we have a world in the scene config, we use it to populate our world
         if(config.contains("world")){
-            world.deserialize(config["world"]);
             world.initializePhysics();
+            world.deserialize(config["world"]);
         }
         // We initialize the camera controller system since it needs a pointer to the app
         inputSystem.enter(getApp());


### PR DESCRIPTION
This pull request introduces changes to improve the handling of rigid bodies, streamline physics initialization, and ensure proper rotation adjustments in the physics system. The most important changes include adding rigid bodies directly to the physics world during initialization, removing redundant physics setup code, and resetting certain rotation components for rigid bodies.

### Physics System Enhancements:
* [`source/common/components/rigid-body.cpp`](diffhunk://#diff-e52ecbbce1b1b1f0a0a17328c4034c9a4ab7681a368bc833502a10c743b121c5R58-R59): Updated the `RigidBodyComponent` to add rigid bodies directly to the physics world during initialization, improving encapsulation and reducing redundant setup steps.
* [`source/common/entities/world.cpp`](diffhunk://#diff-7bbc11d5ae0de466713dfac2feb40d355a0143d64d78b4450894f271cfc5de1cL47-L65): Removed redundant code that previously added rigid bodies to the physics world and set up the debug drawer, as this is now handled elsewhere.

### Rotation Adjustment:
* [`source/common/systems/physics.hpp`](diffhunk://#diff-0d1c0c526d9fb08bc8ba82e2deefdc6265f7b176d4522b4100e018b0059a5163R27-R46): Added logic to reset the X and Z components of the rotation for rigid bodies to ensure proper alignment, normalizing the rotation before applying it back to the rigid body.

### Initialization Order:
* [`source/states/play-state.hpp`](diffhunk://#diff-4f746cd2b9f298ebb7d1e333cd0c1b138947375cef0a3b7c853ddb7200a23e00L34-R35): Adjusted the order of `deserialize` and `initializePhysics` calls to ensure the world is properly initialized before deserialization.

### Dependency Updates:
* [`source/common/components/rigid-body.cpp`](diffhunk://#diff-e52ecbbce1b1b1f0a0a17328c4034c9a4ab7681a368bc833502a10c743b121c5R2): Added a new include for `entities/world.hpp` to access the `getWorld` method for managing physics.