### PR TITLE
Fast Play state restart

### DIFF
--- a/source/common/application.hpp
+++ b/source/common/application.hpp
@@ -36,6 +36,7 @@ namespace our {
         virtual void onImmediateGui(){}                 // Called every frame to draw the Immediate GUI (if any).
         virtual void onDraw(double deltaTime){}         // Called every frame in the game loop passing the time taken to draw the frame "Delta time".
         virtual void onDestroy(){}                      // Called once after the game loop ends for house cleaning.
+        virtual void onRestart(){}                     // Called when the state is restarted.
 
 
         // Override these functions to get mouse and keyboard event.
@@ -104,6 +105,12 @@ namespace our {
             auto it = states.find(name);
             if(it != states.end()){
                 nextState = it->second;
+            }
+        }
+
+        void restartState() {
+            if(currentState) {
+                currentState->onRestart(); // Call the onRestart function of the current state
             }
         }
 

--- a/source/common/entities/transform.cpp
+++ b/source/common/entities/transform.cpp
@@ -27,6 +27,7 @@ glm::mat4 Transform::toMat4() const {
 // Deserializes the entity data and components from a json object
 void Transform::deserialize(const nlohmann::json &data) {
   position = data.value("position", position);
+  originalPosition = position; // Store the original position
   rotation = glm::radians(data.value("rotation", glm::degrees(rotation)));
   scale = data.value("scale", scale);
 }

--- a/source/common/entities/transform.hpp
+++ b/source/common/entities/transform.hpp
@@ -9,6 +9,7 @@ namespace our {
     struct Transform {
     public:
         glm::vec3 position = glm::vec3(0, 0, 0); // The position is defined as a vec3. (0,0,0) means no translation
+        glm::vec3 originalPosition = glm::vec3(0, 0, 0);
         glm::vec3 rotation = glm::vec3(0, 0, 0); // The rotation is defined using euler angles (y: yaw, x: pitch, z: roll). (0,0,0) means no rotation
         glm::vec3 scale = glm::vec3(1, 1, 1); // The scale is defined as a vec3. (1,1,1) means no scaling.
 

--- a/source/common/systems/health.hpp
+++ b/source/common/systems/health.hpp
@@ -165,7 +165,7 @@ namespace our {
 
         void destroyEntity(World *world, Entity *entity) {
             if (entity->getComponent<PlayerComponent>()) {
-                app->changeState("play");
+                app->restartState();
                 return;
             }
             // destroy entity2

--- a/source/common/systems/player.hpp
+++ b/source/common/systems/player.hpp
@@ -53,7 +53,7 @@ namespace our
             if (playerComponent && rigidBody)
             {
                 orientCharater(playerEntity, rigidBody, cameraEntity->localTransform.rotation.y);
-                checkPlayerFallDeath(playerEntity);
+                checkPlayerFallDeath(playerEntity, rigidBody);
             }
         }
 
@@ -158,7 +158,7 @@ namespace our
             playerEntity->localTransform.rotation.z = worldTransform.getRotation().getZ();
         }
 
-        void checkPlayerFallDeath(Entity *playerEntity)
+        void checkPlayerFallDeath(Entity *playerEntity, RigidBodyComponent* rigidBody)
         {
             if (!playerEntity)
                 return;
@@ -168,7 +168,23 @@ namespace our
             if (playerY < DEATH_HEIGHT_THRESHOLD)
             {
                 std::cout << "Player died from falling!" << std::endl;
-                app->changeState("play");
+                // return player to starting position; 
+
+                btTransform worldTransform;
+
+                rigidBody->getRigidBody()->getMotionState()->getWorldTransform(worldTransform);
+
+                // set the new origin
+                glm::vec3 center = playerEntity->localTransform.originalPosition;
+                worldTransform.setOrigin(btVector3(
+                    center.x,
+                    center.y,
+                    center.z
+                ));
+
+                rigidBody->getRigidBody()->getMotionState()->setWorldTransform(worldTransform);
+                rigidBody->getRigidBody()->setWorldTransform(worldTransform);
+                rigidBody->getRigidBody()->setLinearVelocity(btVector3(0, 0, 0));
             }
         }
 

--- a/source/states/menu-state.hpp
+++ b/source/states/menu-state.hpp
@@ -192,6 +192,8 @@ class Menustate: public our::State {
         
     }
 
+    void onRestart() override {}
+
     void onDestroy() override {
         // Delete all the allocated resources
         delete rectangle;

--- a/source/states/play-state.hpp
+++ b/source/states/play-state.hpp
@@ -120,6 +120,23 @@ class Playstate : public our::State {
         }
     }
 
+    void onRestart() override {
+        world.clear();
+        world.shutdownPhysics();
+        // Reinitialize the physics world
+        world.initializePhysics();
+
+        
+        auto& config = getApp()->getConfig()["scene"];
+
+        // If we have a world in the scene config, we use it to populate our
+        // world
+        if (config.contains("world")) {
+            world.initializePhysics();
+            world.deserialize(config["world"]);
+        }
+    }
+
     void onDestroy() override {
         // Don't forget to destroy the renderer
         renderer.destroy();


### PR DESCRIPTION
This pull request introduces functionality to restart the current game state and implements changes to improve player reset mechanics and state management. The most important changes include adding an `onRestart` method to states, integrating state restart functionality into the application, and enhancing player reset behavior upon falling.

### State Management Enhancements:
* [`source/common/application.hpp`](diffhunk://#diff-c1fe59bed6883979f1bfd16e4b50fcb0a72e47d0cbda7f4069060a8df5629497R39): Added the `onRestart` method to the `State` interface and implemented `restartState` to invoke this method for the current state. This allows states to reset themselves when restarted. [[1]](diffhunk://#diff-c1fe59bed6883979f1bfd16e4b50fcb0a72e47d0cbda7f4069060a8df5629497R39) [[2]](diffhunk://#diff-c1fe59bed6883979f1bfd16e4b50fcb0a72e47d0cbda7f4069060a8df5629497R111-R116)
* [`source/states/menu-state.hpp`](diffhunk://#diff-d31f47cb09ce131c06806053171855b000f76f1e3fd7927b578213d35cad36e3R195-R196): Implemented an empty `onRestart` method in `Menustate` to conform to the new interface.
* [`source/states/play-state.hpp`](diffhunk://#diff-4f746cd2b9f298ebb7d1e333cd0c1b138947375cef0a3b7c853ddb7200a23e00R123-R139): Implemented `onRestart` in `Playstate` to clear and reinitialize the physics world, then deserialize the scene configuration to reset the state.

### Player Reset Mechanics:
* [`source/common/entities/transform.hpp`](diffhunk://#diff-9813f097827d4a59c6bdb49299fe4a2197705b41751ac345b47e8e4b4e372828R12): Added `originalPosition` to the `Transform` class to store the initial position of entities.
* [`source/common/entities/transform.cpp`](diffhunk://#diff-75a8e50066afa1e4e1515bfb73378e8a794069234c805d83c65af51eeecf44cbR30): Updated `deserialize` to initialize `originalPosition` with the starting position.
* [`source/common/systems/player.hpp`](diffhunk://#diff-e6fce17d110bb3c37fb10cda2a2753c6025339a780e9043f517df307eb2aab6bL171-R187): Enhanced `checkPlayerFallDeath` to reset the player's position and velocity using `originalPosition` when the player falls below the death threshold.

### Integration of Restart Functionality:
* [`source/common/systems/health.hpp`](diffhunk://#diff-f3a7cfc0007f7081754157a248811bd3ce8ee9a0c57c4f69dfcb0579f61175c7L168-R168): Replaced calls to `changeState("play")` with `restartState()` to restart the current state when the player dies.